### PR TITLE
Lazily generate property getter 

### DIFF
--- a/src/Factly/TypeValidator.cs
+++ b/src/Factly/TypeValidator.cs
@@ -30,7 +30,7 @@ namespace Factly
             {
                 var validator = PropertyValidator.Create(property, builder);
 
-                if (validator.Property != null)
+                if (validator != null)
                 {
                     array.Add(validator);
                 }


### PR DESCRIPTION
This makes building 4x faster and uses half the memory. The cost is incurred during validation, but will only occur on the types that are actually traversed.

Before this change:

```
Method |     Mean |    Error |   StdDev |      Gen 0 |     Gen 1 |   Gen 2 | Allocated |
------- |---------:|---------:|---------:|-----------:|----------:|--------:|----------:|
  Build | 852.5 ms | 3.335 ms | 2.956 ms | 18437.5000 | 4687.5000 | 62.5000 | 110.76 MB |
```

After:

```
 Method |     Mean |    Error |   StdDev |      Gen 0 |     Gen 1 | Allocated |
------- |---------:|---------:|---------:|-----------:|----------:|----------:|
  Build | 264.1 ms | 1.396 ms | 1.306 ms | 30375.0000 | 4500.0000 |  50.88 MB |
```